### PR TITLE
enh: support setting cachemodel to none

### DIFF
--- a/src/benchInsert.c
+++ b/src/benchInsert.c
@@ -607,7 +607,7 @@ int geneDbCreateCmd(SDataBase *database, char *command, int remainVnodes) {
             if (cfg->valuestring) {
                 n = snprintf(command + dataLen,
                                         TSDB_MAX_ALLOWED_SQL_LEN - dataLen,
-                            " %s %s", cfg->name, cfg->valuestring);
+                            " %s '%s'", cfg->name, cfg->valuestring);
             } else {
                 n = snprintf(command + dataLen,
                                         TSDB_MAX_ALLOWED_SQL_LEN - dataLen,


### PR DESCRIPTION
Support the following JSON options
……
  "dbinfo": {
                  "name": "d1",
                  "drop": "yes",
                  "vgroups": 4,
                  "buffer": 128,
                  **"cachemodel": "none",**
                  "replica": 1,
                  "stt_trigger": 1
              },
……